### PR TITLE
Upgrade android api 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
     }
 
     defaultConfig {
+        applicationId "org.fasola.minutes"
         minSdkVersion 15
         targetSdkVersion 33
         versionCode 18
@@ -27,7 +28,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    namespace 'org.fasola.minutes'
+    namespace 'org.fasola.fasolaminutes'
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 33
-        versionCode 17
-        versionName "1.5"
+        versionCode 18
+        versionName "1.6"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion "28.0.3"
 
     flavorDimensions "paid"
     productFlavors {
@@ -28,6 +27,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'org.fasola.fasolaminutes'
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId "org.fasola.minutes"
         minSdkVersion 15
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 19
         versionName "1.6"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     productFlavors {
         free {
             dimension "paid"
-            applicationId "org.fasola.fasolaminutes"
+            applicationId "org.fasola.minutes"
         }
         paid {
             dimension "paid"
@@ -19,7 +19,7 @@ android {
         applicationId "org.fasola.minutes"
         minSdkVersion 15
         targetSdkVersion 33
-        versionCode 18
+        versionCode 19
         versionName "1.6"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         applicationId "org.fasola.minutes"
         minSdkVersion 15
         targetSdkVersion 34
-        versionCode 19
+        versionCode 21
         versionName "1.6"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
     buildToolsVersion "28.0.3"
 
     flavorDimensions "paid"
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 17
         versionName "1.5"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    namespace 'org.fasola.fasolaminutes'
+    namespace 'org.fasola.minutes'
 }
 
 repositories {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.fasola.fasolaminutes" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity
             android:name=".SQLiteDebugActivity"
+            android:exported="true"
             android:label="SQLite Debug"
             android:launchMode="singleTop">
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.fasola.fasolaminutes" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -15,6 +14,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
             android:windowSoftInputMode="adjustPan">
@@ -51,7 +51,7 @@
             android:enabled="true"
             android:exported="false" >
         </service>
-		<receiver android:name=".MediaButtonReceiver" >
+		<receiver android:name=".MediaButtonReceiver" android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MEDIA_BUTTON" />
 			</intent-filter>

--- a/app/src/main/java/org/fasola/fasolaminutes/MinutesContract.java
+++ b/app/src/main/java/org/fasola/fasolaminutes/MinutesContract.java
@@ -15,7 +15,7 @@ public class MinutesContract {
     protected MinutesContract() {
     }
 
-    public static final int DB_VERSION = 16;
+    public static final int DB_VERSION = 17;
     public static final int MIN_YEAR = 1995;
     public static final int MAX_YEAR = 2023;
     public static final int SONG_COUNT = 554;

--- a/app/src/main/java/org/fasola/fasolaminutes/MinutesContract.java
+++ b/app/src/main/java/org/fasola/fasolaminutes/MinutesContract.java
@@ -17,7 +17,7 @@ public class MinutesContract {
 
     public static final int DB_VERSION = 16;
     public static final int MIN_YEAR = 1995;
-    public static final int MAX_YEAR = 2022;
+    public static final int MAX_YEAR = 2023;
     public static final int SONG_COUNT = 554;
     public static final String DB_NAME = "minutes.db";
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrades Android API to version 33 (required by Play store). 

Upgrades Gradle plugin to version 7.4.2 

Manual Manifest changes to specify exported:true to get Gradle plugin / API changes to build. 